### PR TITLE
Load environment variable to theme/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 __pycache__
-env/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,21 @@
 SHELL:=/bin/bash
 
+
+#################################################################
+# run from local machine
+#################################################################
 stop: 
 	docker-compose down --remove-orphans
 
+#no buildenv used
 serve:
-	docker-compose run --service-ports local_development_server
+	export MULTI_ENV_VARIABLE="beep" && \
+	export ENV_SPECIFIC_VARIABLE="boop" && \
+	export DATA_CENTER_SPECIFIC_VARIABLE="yeet" && \
+	docker-compose run -e MULTI_ENV_VARIABLE="$$MULTI_ENV_VARIABLE" \
+						-e ENV_SPECIFIC_VARIABLE="$$ENV_SPECIFIC_VARIABLE" \
+						-e DATA_CENTER_SPECIFIC_VARIABLE="$$DATA_CENTER_SPECIFIC_VARIABLE" \
+						--service-ports local_development_server 
 
 # for unix environment with python installed
 docker: 
@@ -12,3 +23,26 @@ docker:
 
 open: 
 	open http://0.0.0.0:7000
+
+
+##############################################################################
+# run from docker container or local machine if buildenv is installed locally
+##############################################################################
+load-env: check-env check-region
+	eval "$$(buildenv -e $(env) -d $(region))" 
+
+exec-build-env: check-env check-region
+	buildenv -e $(env) -d $(region)
+
+#################################################################
+
+
+check-env:
+ifndef env
+	$(error env is not defined)
+endif
+
+check-region:
+ifndef region
+	$(error region is not defined)
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,13 @@
 SHELL:=/bin/bash
 
-
 #################################################################
 # run from local machine
 #################################################################
 stop: 
 	docker-compose down --remove-orphans
 
-#no buildenv used
-serve:
-	export MULTI_ENV_VARIABLE="beep" && \
-	export ENV_SPECIFIC_VARIABLE="boop" && \
-	export DATA_CENTER_SPECIFIC_VARIABLE="yeet" && \
+serve: check-file	
+	source $(file) && \
 	docker-compose run -e MULTI_ENV_VARIABLE="$$MULTI_ENV_VARIABLE" \
 						-e ENV_SPECIFIC_VARIABLE="$$ENV_SPECIFIC_VARIABLE" \
 						-e DATA_CENTER_SPECIFIC_VARIABLE="$$DATA_CENTER_SPECIFIC_VARIABLE" \
@@ -24,15 +20,11 @@ docker:
 open: 
 	open http://0.0.0.0:7000
 
-
 ##############################################################################
 # run from docker container or local machine if buildenv is installed locally
 ##############################################################################
-load-env: check-env check-region
-	eval "$$(buildenv -e $(env) -d $(region))" 
-
-exec-build-env: check-env check-region
-	buildenv -e $(env) -d $(region)
+exec-build-env: check-env check-region check-file
+	buildenv -e $(env) -d $(region) > $(file)
 
 #################################################################
 
@@ -45,4 +37,9 @@ endif
 check-region:
 ifndef region
 	$(error region is not defined)
+endif
+
+check-file:
+ifndef file
+	$(error file is not defined)
 endif

--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ This is a sample repo with a minimal example of the behavior I desire and descri
    ```
    {{ YOU_VAR }}
    ```
-5. load the environment variables and run mkdocs in the same shell session (Makefile in this example uses docker)
-    ```
-    source "env/dev-us-east-1.env" && \
-    mkdocs serve
-    ```
+5. load the environment variables and run `mkdocs` in the same shell session
+   1. manually source / run (assuming you have `mkdocs` and `pip` requirements installed already)
+        ```
+        source "env/dev-us-east-1.env" && \
+        mkdocs serve
+        ```        
+   2. loading handled via docker-compose argument in example Makefile
+        ```
+        make serve file="env/dev-us-east-1.env"
+        ```
+  

--- a/README.md
+++ b/README.md
@@ -40,4 +40,11 @@ This is a sample repo with a minimal example of the behavior I desire and descri
         ```
         make serve file="env/dev-us-east-1.env"
         ```
-  
+        
+    
+### references
+- https://github.com/honzajavorek/mkdocs-macros-playground
+- https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/
+- https://github.com/Comcast/Buildenv-Tool
+- https://github.com/ntno/docker-containers
+- https://www.mkdocs.org/user-guide/configuration/#environment-variables      

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+# mkdocs-macros-playground
 This is a sample repo with a minimal example of the behavior I desire and describe in [fralau/mkdocs_macros_plugin#75](https://github.com/fralau/mkdocs_macros_plugin/issues/75).
 
 ## ntno fork reqs
 - docker
 - make
+- docker image with [buildenv](https://github.com/Comcast/Buildenv-Tool/), python, mkdocs installed (see [`ntno/ubuntu-build-base`](https://github.com/ntno/docker-containers/tree/main/ubuntu-build-base))

--- a/README.md
+++ b/README.md
@@ -5,3 +5,33 @@ This is a sample repo with a minimal example of the behavior I desire and descri
 - docker
 - make
 - docker image with [buildenv](https://github.com/Comcast/Buildenv-Tool/), python, mkdocs installed (see [`ntno/ubuntu-build-base`](https://github.com/ntno/docker-containers/tree/main/ubuntu-build-base))
+
+
+## ntno fork example use case
+
+1. generate an environment variable file
+   1. manually create file (see [env/](https://github.com/ntno/mkdocs-macros-playground/tree/main/env) for examples)
+   2. OR use [`buildenv`](https://github.com/Comcast/Buildenv-Tool) and a  custom [`variables.yml`](https://github.com/ntno/mkdocs-macros-playground/blob/main/variables.yml) file  
+        ```
+        make docker
+        make exec-build-env env=dev region=us-east-1 file="env/dev-us-east-1.env"
+        exit
+        ```
+2. add variables to `mkdocs.yml` in the `extra` section
+    ````
+    extra:
+        YOUR_VAR: !ENV [YOUR_ENV, 'some default value']
+    ```` 
+3. reference variables in the theme:
+    ```
+    {{ config.extra.YOUR_VAR }}
+    ```
+4. reference variables in the docs:
+   ```
+   {{ YOU_VAR }}
+   ```
+5. load the environment variables and run mkdocs in the same shell session (Makefile in this example uses docker)
+    ```
+    source "env/dev-us-east-1.env" && \
+    mkdocs serve
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,4 +13,10 @@ Dynamic means it's set by a Python code:
 
 - Printing `dynamic_macros_var`: {{ dynamic_macros_var }}
 - Printing `dynamic_extra_var`: {{ dynamic_extra_var }}
-- Printing `dynamic_meta_var`: {{ dynamic_meta_var }}
+- Printing `dynamic_meta_var`: {{ dynamic_meta_var }}  
+
+Shell environment:  
+
+- Printing `MULTI_ENV_VARIABLE`: {{ MULTI_ENV_VARIABLE }}
+- Printing `ENV_SPECIFIC_VARIABLE`: {{ ENV_SPECIFIC_VARIABLE }}
+- Printing `DATA_CENTER_SPECIFIC_VARIABLE`: {{ DATA_CENTER_SPECIFIC_VARIABLE }}

--- a/env/dev-us-east-1.env
+++ b/env/dev-us-east-1.env
@@ -1,0 +1,13 @@
+# Setting Variables for:
+# Environment: dev
+# Datacenter: us-east-1
+# Global Vars:
+export MULTI_ENV_VARIABLE="works! a variable which is the same across environments"
+# Global Secrets:
+# Environment (dev) Vars:
+export ENV_SPECIFIC_VARIABLE="works! development"
+# Environment (dev) Secrets:
+# Datacenter (dev) Specific Vars:
+export AWS_REGION="us-east-1"
+export DATA_CENTER_SPECIFIC_VARIABLE="works! us-east-1 datacenter"
+# Datacenter (dev) Specific Secrets:

--- a/env/dev-us-west-1.env
+++ b/env/dev-us-west-1.env
@@ -1,0 +1,13 @@
+# Setting Variables for:
+# Environment: dev
+# Datacenter: us-west-1
+# Global Vars:
+export MULTI_ENV_VARIABLE="works! a variable which is the same across environments"
+# Global Secrets:
+# Environment (dev) Vars:
+export ENV_SPECIFIC_VARIABLE="works! development"
+# Environment (dev) Secrets:
+# Datacenter (dev) Specific Vars:
+export AWS_REGION="us-west-1"
+export DATA_CENTER_SPECIFIC_VARIABLE="works! us-west-1 datacenter"
+# Datacenter (dev) Specific Secrets:

--- a/env/prod-us-east-1.env
+++ b/env/prod-us-east-1.env
@@ -1,0 +1,13 @@
+# Setting Variables for:
+# Environment: prod
+# Datacenter: us-east-1
+# Global Vars:
+export MULTI_ENV_VARIABLE="works! a variable which is the same across environments"
+# Global Secrets:
+# Environment (prod) Vars:
+export ENV_SPECIFIC_VARIABLE="works! production"
+# Environment (prod) Secrets:
+# Datacenter (prod) Specific Vars:
+export AWS_REGION="us-east-1"
+export DATA_CENTER_SPECIFIC_VARIABLE="works! us-east-1 datacenter"
+# Datacenter (prod) Specific Secrets:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,3 +9,6 @@ plugins:
 
 extra:
   static_extra_var: 'works!'
+  MULTI_ENV_VARIABLE: !ENV [MULTI_ENV_VARIABLE, 'did not work for MULTI_ENV_VARIABLE, loaded default from mkdocs.yml']
+  ENV_SPECIFIC_VARIABLE: !ENV [ENV_SPECIFIC_VARIABLE, 'did not work for ENV_SPECIFIC_VARIABLE, loaded default from mkdocs.yml']
+  DATA_CENTER_SPECIFIC_VARIABLE: !ENV [DATA_CENTER_SPECIFIC_VARIABLE, 'did not work for DATA_CENTER_SPECIFIC_VARIABLE, loaded default from mkdocs.yml']

--- a/theme/main.html
+++ b/theme/main.html
@@ -1,13 +1,17 @@
 {{ page.title }}
-<hr>
-{{ page.content }}
+<hr> {{ page.content }}
 <hr>
 <p>
-  Now this is in the theme template, that means MkDocs's very own Jinja2.
+    Now this is in the theme template, that means MkDocs's very own Jinja2.
 </p>
 <ul>
-  <li>Printing <code>static_extra_var</code>: {{ config.extra.static_extra_var|default('DOES NOT WORK') }}</li>
-  <li>Printing <code>static_meta_var</code>: {{ page.meta.static_meta_var|default('DOES NOT WORK') }}</li>
-  <li>Printing <code>dynamic_extra_var</code>: {{ config.extra.dynamic_extra_var|default('DOES NOT WORK') }}</li>
-  <li>Printing <code>dynamic_meta_var</code>: {{ page.meta.dynamic_meta_var|default('DOES NOT WORK') }}</li>
+    <li>Printing <code>static_extra_var</code>: {{ config.extra.static_extra_var|default('DOES NOT WORK') }}</li>
+    <li>Printing <code>static_meta_var</code>: {{ page.meta.static_meta_var|default('DOES NOT WORK') }}</li>
+    <li>Printing <code>dynamic_extra_var</code>: {{ config.extra.dynamic_extra_var|default('DOES NOT WORK') }}</li>
+    <li>Printing <code>dynamic_meta_var</code>: {{ page.meta.dynamic_meta_var|default('DOES NOT WORK') }}</li>
+</ul>
+<ul>
+    <li>Printing <code>MULTI_ENV_VARIABLE</code>: {{ config.extra.MULTI_ENV_VARIABLE|default('DOES NOT WORK') }}</li>
+    <li>Printing <code>ENV_SPECIFIC_VARIABLE</code>: {{ config.extra.ENV_SPECIFIC_VARIABLE|default('DOES NOT WORK') }}</li>
+    <li>Printing <code>DATA_CENTER_SPECIFIC_VARIABLE</code>: {{ config.extra.DATA_CENTER_SPECIFIC_VARIABLE|default('DOES NOT WORK') }}</li>
 </ul>

--- a/variables.yml
+++ b/variables.yml
@@ -1,0 +1,24 @@
+---
+vars: 
+  MULTI_ENV_VARIABLE: "works! a variable which is the same across environments"
+environments:
+  dev:
+    vars:
+      ENV_SPECIFIC_VARIABLE: "works! development"
+    dcs:
+      us-east-1:
+        vars:
+          AWS_REGION: "us-east-1"
+          DATA_CENTER_SPECIFIC_VARIABLE: "works! us-east-1 datacenter" 
+      us-west-1:
+        vars:
+          AWS_REGION: "us-west-1"
+          DATA_CENTER_SPECIFIC_VARIABLE: "works! us-west-1 datacenter"            
+  prod:
+    vars:
+      ENV_SPECIFIC_VARIABLE: "works! production"
+    dcs:
+      us-east-1:
+        vars:
+          AWS_REGION: "us-east-1"
+          DATA_CENTER_SPECIFIC_VARIABLE: "works! us-east-1 datacenter"


### PR DESCRIPTION
- add environment variables to mkdocs extra config
- load environment variables before running mkdocs serve / mkdocs build

TODO
refactor so that you don't need to generate environment file in separate Makefile directive.  would need to mess around with running buildenv from docker one off container and then pass output to mkdocs docker container.